### PR TITLE
BOJ_3649_김윤주

### DIFF
--- a/04월 3주차 - 4주차/목_BOJ_3649/Main_김윤주.java
+++ b/04월 3주차 - 4주차/목_BOJ_3649/Main_김윤주.java
@@ -1,0 +1,63 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+public class 로봇프로젝트_bj_3649 {
+	
+	static int x, N;
+	static int[] rego;
+	static StringBuilder sb = new StringBuilder();
+
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+		while(true) {
+			String temp = br.readLine();
+//			if(temp == null) break;			//백준 제출할때는 이렇게
+			if(temp.equals("")) break;		//이클립스에서 테스트 할때는 이렇게
+			
+			x = Integer.parseInt(temp) * 10000000;		// 나노미터로 단위 통합해줌
+			N = Integer.parseInt(br.readLine());
+			
+			rego = new int[N];
+			
+			for(int i=0; i<N; i++) {
+				rego[i] = Integer.parseInt(br.readLine());
+			}
+			
+			// 이진탐색
+			binary();
+		}
+		
+		// 출력
+		System.out.print(sb);
+	}
+	
+	
+	static void binary() {
+		// 오름차순 정렬
+		Arrays.sort(rego);
+		
+		// 양 끝에서 탐색 시작
+		int left = 0;
+		int right = N-1;
+		
+		while(left < right) {
+			
+			int sum = rego[left] + rego[right];
+			
+			if(sum > x) right--;			// 합이 x보다 크면 오른쪽 인덱스-1
+			else if(sum < x) left++;		// 합이 x보다 작으면 왼쪽 인덱스+1
+			else {							// 두 레고의 합이 x와 같으면 출력문구 sb에 더해주고 return
+				sb.append("yes " + rego[left] + " " + rego[right] + "\n");
+				return;
+			}
+			
+		}
+		
+		// while문이 끝까지 돌고 온 경우 구멍을 막을 수 있는 조각이 없을때이므로 danger sb에 더해줌
+		sb.append("danger" + "\n");
+		
+	}
+
+}


### PR DESCRIPTION
1. 실패 -> 입력이 여러 개의 테스트 케이스로 주어진다는 것을 놓침
2. 시간초과 -> 레고 조각의 수가 최대 1000000개이므로 조합코드 시간초과
3. 성공 -> 이진탐색!!으로 두 포인터의 합과 구멍의 너비를 비교!

- 문제를 제대로 안읽기도 했고ㅠ 이진탐색 문제를 처음 풀어봐서 성공까지 시간이 꽤 오래걸렸습니다.
- 조합으로 풀땐 출력을 위해 두 레고 조각의 길이도 따로 비교하고 정답이 여러개인 경우를 감안하여 두 레고 조각의 차 최대값을 저장하고 비교해줘야 했는데 이진탐색으로 하니 훨씬 깔끔해서 좋았습니다!